### PR TITLE
Release Tooltip as a production component

### DIFF
--- a/projects/demo/src/server/pages.ts
+++ b/projects/demo/src/server/pages.ts
@@ -39,7 +39,7 @@ export const allComponentPages: ComponentPage[] = [
   new ComponentPage("accordion", "Accordion", AccordionDemoComponent),
   new ComponentPage("dialog", "Dialog", DialogDemoComponent),
   new ComponentPage("popover", "Popover", PopoverDemoComponent),
-  new ComponentPage("tooltip", "Tooltip", TooltipDemoComponent),
+  new ComponentPage("tooltip", "Tooltip", TooltipDemoComponent, "prod"),
   new ComponentPage("avatar", "Avatar", AvatarDemoComponent),
   new ComponentPage("alert", "Alert", AlertDemoComponent),
   new ComponentPage("card", "Card", CardDemoComponent),

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -14,6 +14,7 @@ describe("public-api exports", () => {
       "DropdownItemComponent",
       "IconComponent",
       "InputComponent",
+      "TooltipComponent",
     ]);
   });
 });

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -11,3 +11,4 @@ export * from "./lib/components/dropdown/dropdown.item.component";
 export * from "./lib/components/dropdown/dropdown.model";
 export * from "./lib/components/badge/badge.component";
 export * from "./lib/components/button/button.component";
+export * from "./lib/components/tooltip/tooltip.component";


### PR DESCRIPTION
- Mark Tooltip as a prod component in the demo page list so it appears in main navigation.
- Export TooltipComponent from rectangle-ui public API.
- Update public-api export test to include TooltipComponent.
- Verified with: npx ng test rectangle-ui --watch=false --browsers=ChromeHeadless