### PR TITLE
Release separator as a production component

### DIFF
--- a/projects/demo/src/server/pages.ts
+++ b/projects/demo/src/server/pages.ts
@@ -48,7 +48,7 @@ export const allComponentPages: ComponentPage[] = [
   new ComponentPage("checkbox", "Checkbox", CheckboxDemoComponent),
   new ComponentPage("progress", "Progress", ProgressDemoComponent),
   new ComponentPage("skeleton", "Skeleton", SkeletonDemoComponent),
-  new ComponentPage("separator", "Separator", SeparatorDemoComponent),
+  new ComponentPage("separator", "Separator", SeparatorDemoComponent, "prod"),
   new ComponentPage("label", "Label", LabelDemoComponent),
   new ComponentPage("textarea", "Textarea", TextareaDemoComponent, "prod"),
 ];

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -14,6 +14,7 @@ describe("public-api exports", () => {
       "DropdownItemComponent",
       "IconComponent",
       "InputComponent",
+      "SeparatorComponent",
       "TableComponent",
       "TextareaComponent",
       "TooltipComponent",

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -14,3 +14,4 @@ export * from "./lib/components/button/button.component";
 export * from "./lib/components/tooltip/tooltip.component";
 export * from "./lib/components/textarea/textarea.component";
 export * from "./lib/components/table/table.component";
+export * from "./lib/components/separator/separator.component";


### PR DESCRIPTION
- mark Separator as prod in the demo page registry so it appears in production docs nav
- export SeparatorComponent in the public API surface
- update public-api export test to include SeparatorComponent