### PR TITLE
Release the alert component

### DIFF
--- a/projects/demo/src/pages/alert.component.md
+++ b/projects/demo/src/pages/alert.component.md
@@ -2,3 +2,4 @@ This is a component that represents an alert.
 
 - Alerts communicate important status and feedback to users.
 - Supports info, success, warning, and danger variants.
+- Each variant includes a matching Material icon for faster visual scanning.

--- a/projects/demo/src/server/pages.ts
+++ b/projects/demo/src/server/pages.ts
@@ -40,7 +40,7 @@ export const allComponentPages: ComponentPage[] = [
   new ComponentPage("popover", "Popover", PopoverDemoComponent),
   new ComponentPage("tooltip", "Tooltip", TooltipDemoComponent, "prod"),
   new ComponentPage("avatar", "Avatar", AvatarDemoComponent),
-  new ComponentPage("alert", "Alert", AlertDemoComponent),
+  new ComponentPage("alert", "Alert", AlertDemoComponent, "prod"),
   new ComponentPage("card", "Card", CardDemoComponent),
   new ComponentPage("radio-group", "RadioGroup", RadioGroupDemoComponent),
   new ComponentPage("switch", "Switch", SwitchDemoComponent),

--- a/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
@@ -1,18 +1,31 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AlertComponent } from "./alert.component";
+
 describe("AlertComponent", () => {
   let component: AlertComponent;
   let fixture: ComponentFixture<AlertComponent>;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({ imports: [AlertComponent] }).compileComponents();
     fixture = TestBed.createComponent(AlertComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+
   it("should create", () => expect(component).toBeTruthy());
+
+  it("should render an alert region by default", () => {
+    const alertElement: HTMLElement = fixture.nativeElement.querySelector("[role='alert']");
+
+    expect(alertElement).not.toBeNull();
+    expect(alertElement.className).toContain("border-primary-300");
+  });
+
   it("should apply success classes", () => {
     component.variant = "success";
+
     const classes = (component as unknown as { classes: string[] }).classes.join(" ");
+
     expect(classes).toContain("emerald");
   });
 });

--- a/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
@@ -14,18 +14,24 @@ describe("AlertComponent", () => {
 
   it("should create", () => expect(component).toBeTruthy());
 
-  it("should render an alert region by default", () => {
+  it("should render an alert region with an icon by default", () => {
     const alertElement: HTMLElement = fixture.nativeElement.querySelector("[role='alert']");
+    const iconElement: HTMLElement = fixture.nativeElement.querySelector("rui-icon");
 
     expect(alertElement).not.toBeNull();
     expect(alertElement.className).toContain("border-primary-300");
+    expect(alertElement.className).toContain("gap-2");
+    expect(iconElement).not.toBeNull();
   });
 
-  it("should apply success classes", () => {
+  it("should apply success classes and icon", () => {
     component.variant = "success";
+    fixture.detectChanges();
 
     const classes = (component as unknown as { classes: string[] }).classes.join(" ");
+    const icon = (component as unknown as { icon: string }).icon;
 
     expect(classes).toContain("emerald");
+    expect(icon).toContain("<svg");
   });
 });

--- a/projects/rectangle-ui/src/lib/components/alert/alert.component.ts
+++ b/projects/rectangle-ui/src/lib/components/alert/alert.component.ts
@@ -1,18 +1,31 @@
 import { ChangeDetectionStrategy, Component, Input } from "@angular/core";
 import { NgClass } from "@angular/common";
+import {
+  matCheckCircle,
+  matError,
+  matInfo,
+  matWarningAmber,
+} from "@ng-icons/material-icons/baseline";
+import { IconComponent } from "@/components/icon/icon.component";
 
 @Component({
   selector: "rui-alert",
-  imports: [NgClass],
+  imports: [NgClass, IconComponent],
   template: `
-    <div role="alert" [ngClass]="classes"><ng-content></ng-content></div>
+    <div role="alert" [ngClass]="classes">
+      <rui-icon class="shrink-0 text-current" [icon]="icon"></rui-icon>
+      <span class="min-w-0 flex-1">
+        <ng-content></ng-content>
+      </span>
+    </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AlertComponent {
   @Input() variant: "info" | "success" | "warning" | "danger" = "info";
+
   protected get classes() {
-    const base = "rounded-xl border px-3 py-2 text-sm font-semibold";
+    const base = "flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold";
     const map = {
       info: "border-primary-300 bg-primary-100 text-primary-900 dark:border-primary-700 dark:bg-primary-900 dark:text-primary-100",
       success:
@@ -23,5 +36,16 @@ export class AlertComponent {
         "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300",
     } as const;
     return [base, map[this.variant]];
+  }
+
+  protected get icon() {
+    const map = {
+      info: matInfo,
+      success: matCheckCircle,
+      warning: matWarningAmber,
+      danger: matError,
+    } as const;
+
+    return map[this.variant];
   }
 }

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -7,6 +7,7 @@ describe("public-api exports", () => {
       .sort();
 
     expect(exportedComponents).toEqual([
+      "AlertComponent",
       "BadgeComponent",
       "ButtonComponent",
       "ComboboxComponent",

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -15,3 +15,4 @@ export * from "./lib/components/tooltip/tooltip.component";
 export * from "./lib/components/textarea/textarea.component";
 export * from "./lib/components/table/table.component";
 export * from "./lib/components/separator/separator.component";
+export * from "./lib/components/alert/alert.component";


### PR DESCRIPTION
- Export `AlertComponent` from the library public API
- Mark Alert as a production component in the demo navigation
- Add variant-matched Material icons to Alert for faster visual scanning
- Add lean Alert coverage for the rendered icon and variant styling