### PR TITLE
Fix alert content wrapper

### DIFF
--- a/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
@@ -14,7 +14,9 @@ describe("AlertComponent", () => {
   let fixture: ComponentFixture<AlertComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [AlertComponent, TestHostComponent] }).compileComponents();
+    await TestBed.configureTestingModule({
+      imports: [AlertComponent, TestHostComponent],
+    }).compileComponents();
     fixture = TestBed.createComponent(AlertComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/alert/alert.component.spec.ts
@@ -1,12 +1,20 @@
+import { Component } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AlertComponent } from "./alert.component";
+
+@Component({
+  standalone: true,
+  imports: [AlertComponent],
+  template: `<rui-alert><p>Projected block content</p></rui-alert>`,
+})
+class TestHostComponent {}
 
 describe("AlertComponent", () => {
   let component: AlertComponent;
   let fixture: ComponentFixture<AlertComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [AlertComponent] }).compileComponents();
+    await TestBed.configureTestingModule({ imports: [AlertComponent, TestHostComponent] }).compileComponents();
     fixture = TestBed.createComponent(AlertComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -22,6 +30,18 @@ describe("AlertComponent", () => {
     expect(alertElement.className).toContain("border-primary-300");
     expect(alertElement.className).toContain("gap-2");
     expect(iconElement).not.toBeNull();
+  });
+
+  it("should wrap projected content in a block container", () => {
+    const hostFixture = TestBed.createComponent(TestHostComponent);
+    hostFixture.detectChanges();
+
+    const contentWrapper: HTMLElement | null = hostFixture.nativeElement.querySelector("[role='alert'] > div");
+    const projectedParagraph: HTMLElement | null = hostFixture.nativeElement.querySelector("[role='alert'] p");
+
+    expect(contentWrapper).not.toBeNull();
+    expect(contentWrapper?.className).toContain("flex-1");
+    expect(projectedParagraph?.parentElement).toBe(contentWrapper);
   });
 
   it("should apply success classes and icon", () => {

--- a/projects/rectangle-ui/src/lib/components/alert/alert.component.ts
+++ b/projects/rectangle-ui/src/lib/components/alert/alert.component.ts
@@ -14,9 +14,9 @@ import { IconComponent } from "@/components/icon/icon.component";
   template: `
     <div role="alert" [ngClass]="classes">
       <rui-icon class="shrink-0 text-current" [icon]="icon"></rui-icon>
-      <span class="min-w-0 flex-1">
+      <div class="min-w-0 flex-1">
         <ng-content></ng-content>
-      </span>
+      </div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
- Use a block wrapper for projected alert content so block-level children render as valid HTML
- Keep the existing flex layout behavior with the same sizing classes
- Add a focused regression test for projected block content