### PR TITLE
Release Breadcrumb to production

### DIFF
--- a/projects/rectangle-ui/src/lib/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/breadcrumb/breadcrumb.component.spec.ts
@@ -1,13 +1,37 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { BreadcrumbComponent } from "./breadcrumb.component";
+
 describe("BreadcrumbComponent", () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({ imports: [BreadcrumbComponent] }).compileComponents();
+
     fixture = TestBed.createComponent(BreadcrumbComponent);
     component = fixture.componentInstance;
+    component.items = [
+      { label: "Home", href: "/" },
+      { label: "Components", href: "/components" },
+      { label: "Breadcrumb" },
+    ];
     fixture.detectChanges();
   });
+
   it("should create", () => expect(component).toBeTruthy());
+
+  it("renders non-terminal items as links", () => {
+    const links = Array.from(fixture.nativeElement.querySelectorAll("a")) as HTMLAnchorElement[];
+
+    expect(links.map((link) => link.textContent?.trim())).toEqual(["Home", "Components"]);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual(["/", "/components"]);
+  });
+
+  it("marks the current page for assistive tech", () => {
+    const currentPage: HTMLSpanElement | null = fixture.nativeElement.querySelector(
+      '[aria-current="page"]'
+    );
+
+    expect(currentPage?.textContent?.trim()).toBe("Breadcrumb");
+  });
 });

--- a/projects/rectangle-ui/src/lib/components/breadcrumb/breadcrumb.component.ts
+++ b/projects/rectangle-ui/src/lib/components/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from "@angular/core";
+
 export type BreadcrumbItem = { label: string; href?: string };
+
 @Component({
   selector: "rui-breadcrumb",
   template: `
@@ -9,16 +11,21 @@ export type BreadcrumbItem = { label: string; href?: string };
         @for (item of items; track item.label; let last = $last) {
           <li class="flex items-center gap-2">
             @if (item.href && !last) {
-              <a [href]="item.href" class="hover:text-primary-900 dark:hover:text-primary-100">
+              <a
+                [href]="item.href"
+                class="transition-colors duration-200 ease-in-out hover:text-primary-900 dark:hover:text-primary-100">
                 {{ item.label }}
               </a>
             } @else {
-              <span [class.text-primary-900]="last" [class.dark:text-primary-100]="last">
+              <span
+                [attr.aria-current]="last ? 'page' : null"
+                [class.text-primary-900]="last"
+                [class.dark:text-primary-100]="last">
                 {{ item.label }}
               </span>
             }
             @if (!last) {
-              <span>/</span>
+              <span aria-hidden="true">/</span>
             }
           </li>
         }

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -9,6 +9,7 @@ describe("public-api exports", () => {
     expect(exportedComponents).toEqual([
       "AlertComponent",
       "BadgeComponent",
+      "BreadcrumbComponent",
       "ButtonComponent",
       "ComboboxComponent",
       "DropdownComponent",

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -15,5 +15,6 @@ export * from "./lib/components/tooltip/tooltip.component";
 export * from "./lib/components/textarea/textarea.component";
 export * from "./lib/components/table/table.component";
 export * from "./lib/components/pagination/pagination.component";
+export * from "./lib/components/breadcrumb/breadcrumb.component";
 export * from "./lib/components/separator/separator.component";
 export * from "./lib/components/alert/alert.component";


### PR DESCRIPTION
- Export `BreadcrumbComponent` from the library public API
- Add breadcrumb accessibility polish for the current page marker and decorative separators
- Add lean component and public API coverage
- `ng test rectangle-ui --watch=false --browsers=ChromeHeadless --include=projects/rectangle-ui/src/lib/components/breadcrumb/**/*.spec.ts --include=projects/rectangle-ui/src/public-api.spec.ts`
- `ng build rectangle-ui`
- `npm run lint:standalone-imports` *(currently fails on pre-existing demo SSR typing errors in `projects/demo/server.ts` and `projects/demo/src/main.server.ts`)*