### PR TITLE
Release Accordion

### DIFF
--- a/projects/demo/src/server/pages.ts
+++ b/projects/demo/src/server/pages.ts
@@ -35,7 +35,7 @@ export const allComponentPages: ComponentPage[] = [
   new ComponentPage("pagination", "Pagination", PaginationDemoComponent, "prod"),
   new ComponentPage("breadcrumb", "Breadcrumb", BreadcrumbDemoComponent, "prod"),
   new ComponentPage("tabs", "Tabs", TabsDemoComponent, "prod"),
-  new ComponentPage("accordion", "Accordion", AccordionDemoComponent),
+  new ComponentPage("accordion", "Accordion", AccordionDemoComponent, "prod"),
   new ComponentPage("dialog", "Dialog", DialogDemoComponent),
   new ComponentPage("popover", "Popover", PopoverDemoComponent),
   new ComponentPage("tooltip", "Tooltip", TooltipDemoComponent, "prod"),

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.demo.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.demo.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AccordionDemoComponent } from "./accordion.component.demo";
+
+describe("AccordionDemoComponent", () => {
+  let fixture: ComponentFixture<AccordionDemoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [AccordionDemoComponent] }).compileComponents();
+    fixture = TestBed.createComponent(AccordionDemoComponent);
+    fixture.detectChanges();
+  });
+
+  it("should anchor the demo host to the top while keeping it centered", () => {
+    expect(fixture.nativeElement.className).toContain("flex");
+    expect(fixture.nativeElement.className).toContain("w-full");
+    expect(fixture.nativeElement.className).toContain("justify-center");
+    expect(fixture.nativeElement.className).toContain("self-start");
+  });
+
+  it("should render the accordion inside a stable-width wrapper", () => {
+    const wrapper = fixture.nativeElement.firstElementChild;
+
+    expect(wrapper.className).toContain("w-full");
+    expect(wrapper.className).toContain("max-w-md");
+    expect(wrapper.querySelector("rui-accordion")).not.toBeNull();
+  });
+});

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.demo.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.demo.ts
@@ -1,13 +1,18 @@
-import { Component } from "@angular/core";
+import { Component, HostBinding } from "@angular/core";
 import { AccordionComponent } from "./accordion.component";
+
 @Component({
   selector: "rui-accordion-demo",
   template: `
-    <rui-accordion [items]="items"></rui-accordion>
+    <div class="w-full max-w-md">
+      <rui-accordion [items]="items"></rui-accordion>
+    </div>
   `,
   imports: [AccordionComponent],
 })
 export class AccordionDemoComponent {
+  @HostBinding("class") hostClasses = "flex w-full justify-center self-start";
+
   items = [
     { title: "Can I cancel anytime?", content: "Yes, you can cancel from billing settings." },
     { title: "Do you offer support?", content: "Yes, email and chat support are included." },

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.spec.ts
@@ -25,18 +25,35 @@ describe("AccordionComponent", () => {
     expect(component.openIndex()).toBe(-1);
   });
 
-  it("should wire accessible trigger and panel attributes", () => {
+  it("should keep stable accessible ids for the same input items", () => {
+    const otherFixture = TestBed.createComponent(AccordionComponent);
+    otherFixture.componentInstance.items = component.items;
+    otherFixture.detectChanges();
+
     const buttons = fixture.nativeElement.querySelectorAll("button");
+    const panels = fixture.nativeElement.querySelectorAll("[role='region']");
+    const otherButtons = otherFixture.nativeElement.querySelectorAll("button");
+    const otherPanels = otherFixture.nativeElement.querySelectorAll("[role='region']");
+
+    expect(buttons[0].id).toBe(otherButtons[0].id);
+    expect(buttons[1].id).toBe(otherButtons[1].id);
+    expect(panels[0].id).toBe(otherPanels[0].id);
+    expect(panels[1].id).toBe(otherPanels[1].id);
+  });
+
+  it("should wire accessible trigger and panel attributes for collapsed and expanded items", () => {
+    const buttons = fixture.nativeElement.querySelectorAll("button");
+    const panels = fixture.nativeElement.querySelectorAll("[role='region']");
 
     expect(buttons[0].getAttribute("aria-expanded")).toBe("false");
+    expect(buttons[0].getAttribute("aria-controls")).toBe(panels[0].id);
+    expect(panels[0].getAttribute("aria-labelledby")).toBe(buttons[0].id);
+    expect(panels[0].hasAttribute("hidden")).toBe(true);
 
     component.toggle(0);
     fixture.detectChanges();
 
-    const panel = fixture.nativeElement.querySelector("[role='region']");
-
     expect(buttons[0].getAttribute("aria-expanded")).toBe("true");
-    expect(buttons[0].getAttribute("aria-controls")).toBe(panel.id);
-    expect(panel.getAttribute("aria-labelledby")).toBe(buttons[0].id);
+    expect(panels[0].hasAttribute("hidden")).toBe(false);
   });
 });

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.spec.ts
@@ -1,19 +1,42 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AccordionComponent } from "./accordion.component";
+
 describe("AccordionComponent", () => {
   let component: AccordionComponent;
   let fixture: ComponentFixture<AccordionComponent>;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({ imports: [AccordionComponent] }).compileComponents();
     fixture = TestBed.createComponent(AccordionComponent);
     component = fixture.componentInstance;
+    component.items = [
+      { title: "First item", content: "First content" },
+      { title: "Second item", content: "Second content" },
+    ];
     fixture.detectChanges();
   });
+
   it("should create", () => expect(component).toBeTruthy());
+
   it("should toggle open index", () => {
     component.toggle(0);
     expect(component.openIndex()).toBe(0);
     component.toggle(0);
     expect(component.openIndex()).toBe(-1);
+  });
+
+  it("should wire accessible trigger and panel attributes", () => {
+    const buttons = fixture.nativeElement.querySelectorAll("button");
+
+    expect(buttons[0].getAttribute("aria-expanded")).toBe("false");
+
+    component.toggle(0);
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector("[role='region']");
+
+    expect(buttons[0].getAttribute("aria-expanded")).toBe("true");
+    expect(buttons[0].getAttribute("aria-controls")).toBe(panel.id);
+    expect(panel.getAttribute("aria-labelledby")).toBe(buttons[0].id);
   });
 });

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.spec.ts
@@ -25,7 +25,7 @@ describe("AccordionComponent", () => {
     expect(component.openIndex()).toBe(-1);
   });
 
-  it("should keep stable accessible ids for the same input items", () => {
+  it("should generate unique fallback ids for multiple instances with the same items", () => {
     const otherFixture = TestBed.createComponent(AccordionComponent);
     otherFixture.componentInstance.items = component.items;
     otherFixture.detectChanges();
@@ -35,10 +35,15 @@ describe("AccordionComponent", () => {
     const otherButtons = otherFixture.nativeElement.querySelectorAll("button");
     const otherPanels = otherFixture.nativeElement.querySelectorAll("[role='region']");
 
-    expect(buttons[0].id).toBe(otherButtons[0].id);
-    expect(buttons[1].id).toBe(otherButtons[1].id);
-    expect(panels[0].id).toBe(otherPanels[0].id);
-    expect(panels[1].id).toBe(otherPanels[1].id);
+    expect(buttons[0].id).not.toBe(otherButtons[0].id);
+    expect(buttons[1].id).not.toBe(otherButtons[1].id);
+    expect(panels[0].id).not.toBe(otherPanels[0].id);
+    expect(panels[1].id).not.toBe(otherPanels[1].id);
+
+    expect(buttons[0].getAttribute("aria-controls")).toBe(panels[0].id);
+    expect(otherButtons[0].getAttribute("aria-controls")).toBe(otherPanels[0].id);
+    expect(panels[0].getAttribute("aria-labelledby")).toBe(buttons[0].id);
+    expect(otherPanels[0].getAttribute("aria-labelledby")).toBe(otherButtons[0].id);
   });
 
   it("should wire accessible trigger and panel attributes for collapsed and expanded items", () => {

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.ts
@@ -1,5 +1,9 @@
 import { ChangeDetectionStrategy, Component, Input, model } from "@angular/core";
+
 export type AccordionItem = { title: string; content: string };
+
+let nextAccordionId = 0;
+
 @Component({
   selector: "rui-accordion",
   template: `
@@ -10,12 +14,19 @@ export type AccordionItem = { title: string; content: string };
           <button
             type="button"
             class="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-semibold text-primary-900 dark:text-primary-100"
+            [attr.aria-controls]="contentId(i)"
+            [attr.aria-expanded]="openIndex() === i"
+            [attr.id]="triggerId(i)"
             (click)="toggle(i)">
             {{ item.title }}
-            <span>{{ openIndex() === i ? "−" : "+" }}</span>
+            <span aria-hidden="true">{{ openIndex() === i ? "−" : "+" }}</span>
           </button>
           @if (openIndex() === i) {
-            <div class="px-3 pb-3 text-sm text-primary-700 dark:text-primary-300">
+            <div
+              class="px-3 pb-3 text-sm text-primary-700 dark:text-primary-300"
+              role="region"
+              [attr.aria-labelledby]="triggerId(i)"
+              [attr.id]="contentId(i)">
               {{ item.content }}
             </div>
           }
@@ -27,8 +38,20 @@ export type AccordionItem = { title: string; content: string };
 })
 export class AccordionComponent {
   @Input() items: AccordionItem[] = [];
+
   openIndex = model<number | -1>(-1);
+
+  private readonly accordionId = `rui-accordion-${nextAccordionId++}`;
+
   toggle(i: number) {
     this.openIndex.set(this.openIndex() === i ? -1 : i);
+  }
+
+  protected triggerId(i: number): string {
+    return `${this.accordionId}-trigger-${i}`;
+  }
+
+  protected contentId(i: number): string {
+    return `${this.accordionId}-content-${i}`;
   }
 }

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.ts
@@ -2,8 +2,6 @@ import { ChangeDetectionStrategy, Component, Input, model } from "@angular/core"
 
 export type AccordionItem = { title: string; content: string };
 
-let nextAccordionId = 0;
-
 @Component({
   selector: "rui-accordion",
   template: `
@@ -21,15 +19,14 @@ let nextAccordionId = 0;
             {{ item.title }}
             <span aria-hidden="true">{{ openIndex() === i ? "−" : "+" }}</span>
           </button>
-          @if (openIndex() === i) {
-            <div
-              class="px-3 pb-3 text-sm text-primary-700 dark:text-primary-300"
-              role="region"
-              [attr.aria-labelledby]="triggerId(i)"
-              [attr.id]="contentId(i)">
-              {{ item.content }}
-            </div>
-          }
+          <div
+            class="px-3 pb-3 text-sm text-primary-700 dark:text-primary-300"
+            role="region"
+            [attr.aria-labelledby]="triggerId(i)"
+            [attr.hidden]="openIndex() === i ? null : ''"
+            [attr.id]="contentId(i)">
+            {{ item.content }}
+          </div>
         </div>
       }
     </div>
@@ -38,20 +35,37 @@ let nextAccordionId = 0;
 })
 export class AccordionComponent {
   @Input() items: AccordionItem[] = [];
+  @Input() id?: string;
 
   openIndex = model<number | -1>(-1);
-
-  private readonly accordionId = `rui-accordion-${nextAccordionId++}`;
 
   toggle(i: number) {
     this.openIndex.set(this.openIndex() === i ? -1 : i);
   }
 
   protected triggerId(i: number): string {
-    return `${this.accordionId}-trigger-${i}`;
+    return `${this.accordionId()}-trigger-${i}`;
   }
 
   protected contentId(i: number): string {
-    return `${this.accordionId}-content-${i}`;
+    return `${this.accordionId()}-content-${i}`;
   }
+
+  private accordionId(): string {
+    return this.id?.trim() || `rui-accordion-${hashAccordionItems(this.items)}`;
+  }
+}
+
+function hashAccordionItems(items: AccordionItem[]): string {
+  let hash = 0;
+
+  for (const item of items) {
+    const value = `${item.title}\u0000${item.content}\u0001`;
+
+    for (let i = 0; i < value.length; i += 1) {
+      hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+    }
+  }
+
+  return hash.toString(36);
 }

--- a/projects/rectangle-ui/src/lib/components/accordion/accordion.component.ts
+++ b/projects/rectangle-ui/src/lib/components/accordion/accordion.component.ts
@@ -1,6 +1,17 @@
-import { ChangeDetectionStrategy, Component, Input, model } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Injectable, Input, inject, model } from "@angular/core";
 
 export type AccordionItem = { title: string; content: string };
+
+@Injectable({ providedIn: "root" })
+class AccordionIdSequence {
+  private nextId = 0;
+
+  next(): number {
+    const id = this.nextId;
+    this.nextId += 1;
+    return id;
+  }
+}
 
 @Component({
   selector: "rui-accordion",
@@ -37,6 +48,8 @@ export class AccordionComponent {
   @Input() items: AccordionItem[] = [];
   @Input() id?: string;
 
+  private readonly fallbackInstanceId = inject(AccordionIdSequence).next();
+
   openIndex = model<number | -1>(-1);
 
   toggle(i: number) {
@@ -52,7 +65,7 @@ export class AccordionComponent {
   }
 
   private accordionId(): string {
-    return this.id?.trim() || `rui-accordion-${hashAccordionItems(this.items)}`;
+    return this.id?.trim() || `rui-accordion-${this.fallbackInstanceId}-${hashAccordionItems(this.items)}`;
   }
 }
 

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -7,6 +7,7 @@ describe("public-api exports", () => {
       .sort();
 
     expect(exportedComponents).toEqual([
+      "AccordionComponent",
       "AlertComponent",
       "BadgeComponent",
       "BreadcrumbComponent",

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -17,5 +17,6 @@ export * from "./lib/components/table/table.component";
 export * from "./lib/components/pagination/pagination.component";
 export * from "./lib/components/breadcrumb/breadcrumb.component";
 export * from "./lib/components/separator/separator.component";
+export * from "./lib/components/accordion/accordion.component";
 export * from "./lib/components/alert/alert.component";
 export * from "./lib/components/progress/progress.component";


### PR DESCRIPTION
- Mark the Accordion component as production-ready in the demo/docs
- Export Accordion from the library public API
- Keep the Accordion demo preview anchored to the top of the preview container while centered horizontally
- Give the demo preview a stable max width so it does not resize or jump on expand
- Add lean demo coverage for the new layout behavior
- Use hydration-safe per-instance fallback IDs combined with the item hash (with an explicit `id` override when needed)
- Keep Accordion panels mounted while collapsed so `aria-controls` always points at a real panel node
- Add lean Accordion tests for collapsed-panel accessibility wiring and multi-instance fallback ID uniqueness