### PR TITLE
[25] Fix demo SSR bootstrap typing

### DIFF
--- a/projects/demo/src/main.server.ts
+++ b/projects/demo/src/main.server.ts
@@ -1,8 +1,7 @@
-import { BootstrapContext, bootstrapApplication } from "@angular/platform-browser";
+import { bootstrapApplication } from "@angular/platform-browser";
 import { AppComponent } from "./app/app.component";
 import { config } from "./app/app.config.server";
 
-const bootstrap = (context: BootstrapContext) =>
-  bootstrapApplication(AppComponent, config, context);
+const bootstrap = () => bootstrapApplication(AppComponent, config);
 
 export default bootstrap;

--- a/projects/demo/src/main.server.ts
+++ b/projects/demo/src/main.server.ts
@@ -1,7 +1,13 @@
+import { ApplicationRef } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { AppComponent } from "./app/app.component";
 import { config } from "./app/app.config.server";
 
-const bootstrap = () => bootstrapApplication(AppComponent, config);
+const bootstrap = ((context?: unknown) =>
+  (bootstrapApplication as (...args: unknown[]) => Promise<ApplicationRef>)(
+    AppComponent,
+    config,
+    context
+  )) as () => Promise<ApplicationRef>;
 
 export default bootstrap;


### PR DESCRIPTION
- Forward the optional SSR bootstrap context through the demo server entry so Angular prerender route extraction has the server platform it expects.
- Keep the exported bootstrap compatible with the current Angular 19 `CommonEngine` typing.
- Restore `npm run build` and unblock the downstream Vercel deployment.