### PR TITLE
Release tabs for production

### DIFF
--- a/projects/rectangle-ui/src/lib/components/tabs/tabs.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/tabs/tabs.component.spec.ts
@@ -38,12 +38,15 @@ describe("TabsComponent", () => {
   });
 
   it("should support arrow key navigation", () => {
+    const buttons: HTMLButtonElement[] = Array.from(fixture.nativeElement.querySelectorAll("button"));
     const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
 
+    buttons[0].focus();
     fixture.nativeElement.dispatchEvent(event);
     fixture.detectChanges();
 
     expect(component.active()).toBe("usage");
+    expect(document.activeElement).toBe(buttons[1]);
   });
 
   it("should expose tablist semantics", () => {

--- a/projects/rectangle-ui/src/lib/components/tabs/tabs.component.spec.ts
+++ b/projects/rectangle-ui/src/lib/components/tabs/tabs.component.spec.ts
@@ -1,26 +1,58 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { TabsComponent } from "./tabs.component";
+
 describe("TabsComponent", () => {
   let component: TabsComponent;
   let fixture: ComponentFixture<TabsComponent>;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({ imports: [TabsComponent] }).compileComponents();
+
     fixture = TestBed.createComponent(TabsComponent);
     component = fixture.componentInstance;
-    component.tabs = [{ label: "Overview", value: "overview" }];
+    component.tabs = [
+      { label: "Overview", value: "overview" },
+      { label: "Usage", value: "usage" },
+      { label: "Billing", value: "billing" },
+    ];
     fixture.detectChanges();
   });
-  it("should create", () => expect(component).toBeTruthy());
-  it("should set active tab", () => {
-    component.active.set("usage");
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should default to the first tab when the active value is missing", () => {
+    expect(component.active()).toBe("overview");
+  });
+
+  it("should set active tab on click", () => {
+    const buttons = fixture.nativeElement.querySelectorAll("button");
+
+    buttons[1].click();
+    fixture.detectChanges();
+
+    expect(component.active()).toBe("usage");
+    expect(buttons[1].getAttribute("aria-selected")).toBe("true");
+    expect(buttons[1].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should support arrow key navigation", () => {
+    const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
+
+    fixture.nativeElement.dispatchEvent(event);
+    fixture.detectChanges();
+
     expect(component.active()).toBe("usage");
   });
 
-  it("should include hover styles on tab buttons", () => {
+  it("should expose tablist semantics", () => {
+    const tablist: HTMLElement = fixture.nativeElement.querySelector('[role="tablist"]');
     const button: HTMLButtonElement = fixture.nativeElement.querySelector("button");
-    expect(button).toBeTruthy();
+
+    expect(tablist.getAttribute("aria-label")).toBe("Tabs");
+    expect(button.getAttribute("role")).toBe("tab");
     expect(button.className).toContain("hover:bg-primary-200");
     expect(button.className).toContain("dark:hover:bg-primary-800");
   });
-
 });

--- a/projects/rectangle-ui/src/lib/components/tabs/tabs.component.ts
+++ b/projects/rectangle-ui/src/lib/components/tabs/tabs.component.ts
@@ -1,12 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   HostListener,
   Injectable,
   Input,
   OnChanges,
   OnInit,
+  QueryList,
   SimpleChanges,
+  ViewChildren,
   inject,
   model,
 } from "@angular/core";
@@ -34,6 +37,7 @@ class TabsIdSequence {
         [attr.aria-label]="ariaLabel">
         @for (tab of tabs; track tab.value; let i = $index) {
           <button
+            #tabButton
             type="button"
             class="rounded-lg px-3 py-1 text-sm font-semibold text-primary-900 transition-colors duration-200 ease-in-out hover:bg-primary-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-100 dark:hover:bg-primary-800"
             role="tab"
@@ -58,6 +62,8 @@ export class TabsComponent implements OnChanges, OnInit {
 
   private readonly fallbackInstanceId = inject(TabsIdSequence).next();
 
+  @ViewChildren("tabButton") private readonly tabButtons?: QueryList<ElementRef<HTMLButtonElement>>;
+
   active = model("");
 
   ngOnInit(): void {
@@ -70,7 +76,7 @@ export class TabsComponent implements OnChanges, OnInit {
     }
   }
 
-  activate(index: number): void {
+  activate(index: number, options?: { focus?: boolean }): void {
     const tab = this.tabs[index];
 
     if (!tab) {
@@ -78,6 +84,10 @@ export class TabsComponent implements OnChanges, OnInit {
     }
 
     this.active.set(tab.value);
+
+    if (options?.focus) {
+      this.tabButtons?.get(index)?.nativeElement.focus();
+    }
   }
 
   @HostListener("keydown", ["$event"])
@@ -92,20 +102,20 @@ export class TabsComponent implements OnChanges, OnInit {
       case "ArrowRight":
       case "ArrowDown":
         event.preventDefault();
-        this.activate((selectedIndex + 1) % this.tabs.length);
+        this.activate((selectedIndex + 1) % this.tabs.length, { focus: true });
         break;
       case "ArrowLeft":
       case "ArrowUp":
         event.preventDefault();
-        this.activate((selectedIndex - 1 + this.tabs.length) % this.tabs.length);
+        this.activate((selectedIndex - 1 + this.tabs.length) % this.tabs.length, { focus: true });
         break;
       case "Home":
         event.preventDefault();
-        this.activate(0);
+        this.activate(0, { focus: true });
         break;
       case "End":
         event.preventDefault();
-        this.activate(this.tabs.length - 1);
+        this.activate(this.tabs.length - 1, { focus: true });
         break;
     }
   }

--- a/projects/rectangle-ui/src/lib/components/tabs/tabs.component.ts
+++ b/projects/rectangle-ui/src/lib/components/tabs/tabs.component.ts
@@ -1,18 +1,48 @@
-import { ChangeDetectionStrategy, Component, Input, model } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostListener,
+  Injectable,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  inject,
+  model,
+} from "@angular/core";
+
 export type TabItem = { label: string; value: string };
+
+@Injectable({ providedIn: "root" })
+class TabsIdSequence {
+  private nextId = 0;
+
+  next(): number {
+    const id = this.nextId;
+    this.nextId += 1;
+    return id;
+  }
+}
+
 @Component({
   selector: "rui-tabs",
   template: `
     <div class="space-y-3">
       <div
-        class="inline-flex gap-1 rounded-xl border border-primary-300 bg-primary-100 p-1 dark:border-primary-800 dark:bg-primary-900">
-        @for (tab of tabs; track tab.value) {
+        class="inline-flex gap-1 rounded-xl border border-primary-300 bg-primary-100 p-1 dark:border-primary-800 dark:bg-primary-900"
+        role="tablist"
+        [attr.aria-label]="ariaLabel">
+        @for (tab of tabs; track tab.value; let i = $index) {
           <button
             type="button"
-            class="rounded-lg px-3 py-1 text-sm font-semibold transition-colors duration-200 ease-in-out hover:bg-primary-200 dark:hover:bg-primary-800"
-            [class.bg-primary-200]="active() === tab.value"
-            [class.dark:bg-primary-800]="active() === tab.value"
-            (click)="active.set(tab.value)">
+            class="rounded-lg px-3 py-1 text-sm font-semibold text-primary-900 transition-colors duration-200 ease-in-out hover:bg-primary-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-100 dark:hover:bg-primary-800"
+            role="tab"
+            [attr.id]="tabId(i)"
+            [attr.tabindex]="selectedIndex() === i ? 0 : -1"
+            [attr.aria-selected]="selectedIndex() === i"
+            [class.bg-primary-200]="selectedIndex() === i"
+            [class.dark:bg-primary-800]="selectedIndex() === i"
+            (click)="activate(i)">
             {{ tab.label }}
           </button>
         }
@@ -21,7 +51,103 @@ export type TabItem = { label: string; value: string };
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TabsComponent {
+export class TabsComponent implements OnChanges, OnInit {
   @Input() tabs: TabItem[] = [];
+  @Input() id?: string;
+  @Input() ariaLabel = "Tabs";
+
+  private readonly fallbackInstanceId = inject(TabsIdSequence).next();
+
   active = model("");
+
+  ngOnInit(): void {
+    this.ensureValidActiveTab();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["tabs"]) {
+      this.ensureValidActiveTab();
+    }
+  }
+
+  activate(index: number): void {
+    const tab = this.tabs[index];
+
+    if (!tab) {
+      return;
+    }
+
+    this.active.set(tab.value);
+  }
+
+  @HostListener("keydown", ["$event"])
+  protected onKeydown(event: KeyboardEvent): void {
+    if (this.tabs.length === 0) {
+      return;
+    }
+
+    const selectedIndex = this.selectedIndex();
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        this.activate((selectedIndex + 1) % this.tabs.length);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        this.activate((selectedIndex - 1 + this.tabs.length) % this.tabs.length);
+        break;
+      case "Home":
+        event.preventDefault();
+        this.activate(0);
+        break;
+      case "End":
+        event.preventDefault();
+        this.activate(this.tabs.length - 1);
+        break;
+    }
+  }
+
+  protected selectedIndex(): number {
+    const activeIndex = this.tabs.findIndex((tab) => tab.value === this.active());
+    return activeIndex >= 0 ? activeIndex : 0;
+  }
+
+  protected tabId(index: number): string {
+    return `${this.tabsId()}-tab-${index}`;
+  }
+
+  private ensureValidActiveTab(): void {
+    if (this.tabs.length === 0) {
+      if (this.active() !== "") {
+        this.active.set("");
+      }
+
+      return;
+    }
+
+    if (!this.tabs.some((tab) => tab.value === this.active())) {
+      this.active.set(this.tabs[0].value);
+    }
+  }
+
+  private tabsId(): string {
+    return this.id?.trim() || `rui-tabs-${this.fallbackInstanceId}-${hashTabs(this.tabs)}`;
+  }
+}
+
+function hashTabs(tabs: TabItem[]): string {
+  let hash = 0;
+
+  for (const tab of tabs) {
+    const value = `${tab.label}\u0000${tab.value}\u0001`;
+
+    for (let i = 0; i < value.length; i += 1) {
+      hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+    }
+  }
+
+  return hash.toString(36);
 }

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -21,6 +21,7 @@ describe("public-api exports", () => {
       "ProgressComponent",
       "SeparatorComponent",
       "TableComponent",
+      "TabsComponent",
       "TextareaComponent",
       "TooltipComponent",
     ]);

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -16,6 +16,7 @@ export * from "./lib/components/textarea/textarea.component";
 export * from "./lib/components/table/table.component";
 export * from "./lib/components/pagination/pagination.component";
 export * from "./lib/components/breadcrumb/breadcrumb.component";
+export * from "./lib/components/tabs/tabs.component";
 export * from "./lib/components/separator/separator.component";
 export * from "./lib/components/accordion/accordion.component";
 export * from "./lib/components/alert/alert.component";


### PR DESCRIPTION
- export TabsComponent from the public API so it ships with the library
- add accessible tab semantics, focus styles, default selection, keyboard navigation, and keyboard focus movement so focus stays with the active tab
- extend tabs tests to cover the new behavior and keep the release scoped to the tabs component