### PR TITLE
Release skeleton component

### DIFF
--- a/projects/demo/src/app.components/page/page.component.ts
+++ b/projects/demo/src/app.components/page/page.component.ts
@@ -2,7 +2,7 @@ import { afterRender, Component, computed, HostBinding, input } from "@angular/c
 import { MarkdownComponent, provideMarkdown } from "ngx-markdown";
 import { HttpClient } from "@angular/common/http";
 import { ActivatedRoute, RouterOutlet } from "@angular/router";
-import { mainPages } from "../../server/pages";
+import { allComponentPages, mainPages, readmePage } from "../../server/pages";
 import { IconComponent } from "@/components/icon/icon.component";
 import { matConstruction } from "@ng-icons/material-icons/baseline";
 
@@ -59,7 +59,15 @@ import { matConstruction } from "@ng-icons/material-icons/baseline";
 })
 export class PageComponent {
   componentId = input<string>();
-  component = computed(() => mainPages.find((component) => component.id === this.componentId()));
+  component = computed(() => {
+    const id = this.componentId();
+
+    return (
+      allComponentPages.find((component) => component.id === id) ??
+      (readmePage.id === id ? readmePage : undefined) ??
+      mainPages.find((component) => component.id === id)
+    );
+  });
 
   @HostBinding("class") hostClass: string = "flex w-full flex-col gap-8 px-4";
 

--- a/projects/demo/src/server/pages.ts
+++ b/projects/demo/src/server/pages.ts
@@ -46,7 +46,7 @@ export const allComponentPages: ComponentPage[] = [
   new ComponentPage("switch", "Switch", SwitchDemoComponent),
   new ComponentPage("checkbox", "Checkbox", CheckboxDemoComponent),
   new ComponentPage("progress", "Progress", ProgressDemoComponent, "prod"),
-  new ComponentPage("skeleton", "Skeleton", SkeletonDemoComponent),
+  new ComponentPage("skeleton", "Skeleton", SkeletonDemoComponent, "prod"),
   new ComponentPage("separator", "Separator", SeparatorDemoComponent, "prod"),
   new ComponentPage("textarea", "Textarea", TextareaDemoComponent, "prod"),
 ];

--- a/projects/rectangle-ui/src/lib/components/skeleton/skeleton.component.demo.ts
+++ b/projects/rectangle-ui/src/lib/components/skeleton/skeleton.component.demo.ts
@@ -23,5 +23,5 @@ import { SkeletonComponent } from "./skeleton.component";
   imports: [SkeletonComponent],
 })
 export class SkeletonDemoComponent {
-  @HostBinding("class") hostClasses = "block w-full";
+  @HostBinding("class") hostClasses = "flex w-full justify-center";
 }

--- a/projects/rectangle-ui/src/lib/components/skeleton/skeleton.component.demo.ts
+++ b/projects/rectangle-ui/src/lib/components/skeleton/skeleton.component.demo.ts
@@ -1,15 +1,27 @@
-import { Component } from "@angular/core";
+import { Component, HostBinding } from "@angular/core";
 import { SkeletonComponent } from "./skeleton.component";
 
 @Component({
   selector: "rui-skeleton-demo",
   template: `
-    <div class="w-full max-w-md space-y-2">
-      <rui-skeleton height="1.25rem"></rui-skeleton>
-      <rui-skeleton width="80%" height="1.25rem"></rui-skeleton>
-      <rui-skeleton width="60%" height="1.25rem"></rui-skeleton>
+    <div class="w-full max-w-md rounded-2xl border border-primary-300 bg-primary-50 p-4 dark:border-primary-800 dark:bg-primary-900/40">
+      <div class="flex items-center gap-3">
+        <rui-skeleton width="3rem" height="3rem"></rui-skeleton>
+        <div class="flex-1 space-y-2">
+          <rui-skeleton width="45%" height="1rem"></rui-skeleton>
+          <rui-skeleton width="70%" height="0.875rem"></rui-skeleton>
+        </div>
+      </div>
+
+      <div class="mt-4 space-y-2">
+        <rui-skeleton height="1rem"></rui-skeleton>
+        <rui-skeleton width="92%" height="1rem"></rui-skeleton>
+        <rui-skeleton width="78%" height="1rem"></rui-skeleton>
+      </div>
     </div>
   `,
   imports: [SkeletonComponent],
 })
-export class SkeletonDemoComponent {}
+export class SkeletonDemoComponent {
+  @HostBinding("class") hostClasses = "block w-full";
+}

--- a/projects/rectangle-ui/src/public-api.spec.ts
+++ b/projects/rectangle-ui/src/public-api.spec.ts
@@ -20,6 +20,7 @@ describe("public-api exports", () => {
       "PaginationComponent",
       "ProgressComponent",
       "SeparatorComponent",
+      "SkeletonComponent",
       "TableComponent",
       "TabsComponent",
       "TextareaComponent",

--- a/projects/rectangle-ui/src/public-api.ts
+++ b/projects/rectangle-ui/src/public-api.ts
@@ -21,3 +21,4 @@ export * from "./lib/components/separator/separator.component";
 export * from "./lib/components/accordion/accordion.component";
 export * from "./lib/components/alert/alert.component";
 export * from "./lib/components/progress/progress.component";
+export * from "./lib/components/skeleton/skeleton.component";


### PR DESCRIPTION
- Export `SkeletonComponent` from the public rectangle-ui API.
- Make Skeleton visible in the production demo/component index.
- Resolve demo pages from the full page dataset so registered component pages render reliably.
- Make the Skeleton preview more visible and representative in the demo page.
- Add/extend the public API export contract test for the skeleton component.
