### PR TITLE
fix: Replace avatar demo image asset

### DIFF
--- a/projects/demo/public/avatar-demo.svg
+++ b/projects/demo/public/avatar-demo.svg
@@ -1,0 +1,5 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="128" height="128" rx="64" fill="#E0E7FF"/>
+  <circle cx="64" cy="48" r="24" fill="#4338CA"/>
+  <path d="M24 112C24 87.6995 41.9086 68 64 68C86.0914 68 104 87.6995 104 112" fill="#6366F1"/>
+</svg>

--- a/projects/rectangle-ui/src/lib/components/avatar/avatar.component.demo.ts
+++ b/projects/rectangle-ui/src/lib/components/avatar/avatar.component.demo.ts
@@ -5,7 +5,7 @@ import { AvatarComponent } from "./avatar.component";
   template: `
     <div class="flex flex-wrap items-center gap-4">
       <div class="flex flex-col items-center gap-2 text-xs text-primary-700 dark:text-primary-200">
-        <rui-avatar src="/img/sad_pikachu.png" alt="Pikachu avatar" fallback="PK"></rui-avatar>
+        <rui-avatar src="/avatar-demo.svg" alt="Avatar demo illustration" fallback="AD"></rui-avatar>
         <span>Image</span>
       </div>
 


### PR DESCRIPTION
## Summary

Replaced the avatar demo's old image reference with a new local SVG illustration asset that ships with the demo app.

## Changes

- added `projects/demo/public/avatar-demo.svg` as the replacement demo avatar asset
- updated the avatar demo to render the new local asset for the image example
- kept the fallback-only avatar example unchanged

## Testing

- `npx ng test rectangle-ui --watch=false --browsers=ChromeHeadless`
- `npx ng build demo`

Fixes jarretthuang/rectangle-ui#32